### PR TITLE
fix grpcgo workflow for empty repositories

### DIFF
--- a/pkg/generate/grpcgo/template.go
+++ b/pkg/generate/grpcgo/template.go
@@ -79,8 +79,10 @@ jobs:
       - name: Go Mod Tidy
         working-directory: "${{ "{{" }} runner.temp {{ "}}" }}/{{ .Github.Organization }}/{{ .Github.Repository }}/"
         run: |
-          rm -f go.sum
-          go mod tidy
+          if [[ -e go.sum ]]; then
+            rm -f go.sum
+            go mod tidy
+          fi
 
       - name: Commit And Push
         env:

--- a/pkg/generate/grpcgo/testdata/grpcgo/case-0.golden
+++ b/pkg/generate/grpcgo/testdata/grpcgo/case-0.golden
@@ -77,8 +77,10 @@ jobs:
       - name: Go Mod Tidy
         working-directory: "${{ runner.temp }}/xh3b4sd/gocode/"
         run: |
-          rm -f go.sum
-          go mod tidy
+          if [[ -e go.sum ]]; then
+            rm -f go.sum
+            go mod tidy
+          fi
 
       - name: Commit And Push
         env:

--- a/pkg/generate/grpcgo/testdata/grpcgo/case-1.golden
+++ b/pkg/generate/grpcgo/testdata/grpcgo/case-1.golden
@@ -77,8 +77,10 @@ jobs:
       - name: Go Mod Tidy
         working-directory: "${{ runner.temp }}/some-org/some-repo/"
         run: |
-          rm -f go.sum
-          go mod tidy
+          if [[ -e go.sum ]]; then
+            rm -f go.sum
+            go mod tidy
+          fi
 
       - name: Commit And Push
         env:


### PR DESCRIPTION
I noticed that the workflow fails on empty repositories which should get automatically initialized with generated code. 