### PR TITLE
add separate build step to golang workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,8 +6,8 @@
 #
 
 version: 2
-updates:
 
+updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     ignore:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,7 +2,7 @@
 # Do not edit. This file was generated via the "workflow" command line tool.
 # More information about the tool can be found at github.com/xh3b4sd/workflow.
 #
-#     workflow create dependabot -b master -r xh3b4sd
+#     workflow create dependabot -r xh3b4sd
 #
 
 version: 2
@@ -19,7 +19,7 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    target-branch: "master"
+    target-branch: "main"
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -32,4 +32,4 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    target-branch: "master"
+    target-branch: "main"

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -13,7 +13,6 @@ jobs:
   go-build:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 
@@ -28,7 +27,7 @@ jobs:
           go mod tidy
           git diff --exit-code
 
-      - name: "Build Go Binary"
+      - name: "Run Go Build"
         env:
           CGO_ENABLED: "0"
         run: |

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -28,6 +28,12 @@ jobs:
           go mod tidy
           git diff --exit-code
 
+      - name: "Build Go Binary"
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          go build .
+
       - name: "Check Go Tests"
         run: |
           go test ./... -race

--- a/cmd/create/dependabot/template.go
+++ b/cmd/create/dependabot/template.go
@@ -8,8 +8,9 @@ const templateWorkflow = `#
 #
 
 version: 2
+
 updates:
-{{ range $e := .Ecosystems }}
+{{- range $e := .Ecosystems }}
   - package-ecosystem: "{{ $e.Name }}"
     directory: "/"
     ignore:

--- a/cmd/create/dockergo/template.go
+++ b/cmd/create/dockergo/template.go
@@ -15,7 +15,6 @@ jobs:
   docker-go:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"
 

--- a/cmd/create/dockerts/template.go
+++ b/cmd/create/dockerts/template.go
@@ -15,7 +15,6 @@ jobs:
   docker-ts:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"
 

--- a/cmd/create/dsmupdate/template.go
+++ b/cmd/create/dsmupdate/template.go
@@ -19,7 +19,6 @@ jobs:
   dsm-update:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"
 

--- a/cmd/create/dsmverify/template.go
+++ b/cmd/create/dsmverify/template.go
@@ -14,7 +14,6 @@ on: "push"
 jobs:
   dsm-verify:
     runs-on: "ubuntu-latest"
-
     steps:
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"

--- a/cmd/create/golang/flag.go
+++ b/cmd/create/golang/flag.go
@@ -10,6 +10,7 @@ import (
 )
 
 type flag struct {
+	Binary  bool
 	Private string
 	User    string
 	Version struct {
@@ -18,6 +19,7 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&f.Binary, "binary", "b", true, "Whether to add the 'go build .' or 'go build ./...' build step.")
 	cmd.Flags().StringVarP(&f.Private, "private", "p", "", "GOPRIVATE string, e.g. github.com/org/rep.")
 	cmd.Flags().StringVarP(&f.User, "user", "u", "", "Github user for GOPRIVATE authentication, e.g. xh3b4sd.")
 	cmd.Flags().StringVarP(&f.Version.Golang, "version-golang", "g", version.Golang, "Golang version to use in, e.g. workflow files.")

--- a/cmd/create/golang/runner.go
+++ b/cmd/create/golang/runner.go
@@ -79,7 +79,7 @@ func (r *runner) run() error {
 		} else if err != nil {
 			return tracer.Mask(err)
 		} else {
-			c := strings.Replace(string(b), currentVersion(b), desiredVersion(r.flag.Version.Golang), -1)
+			c := strings.ReplaceAll(string(b), currentVersion(b), desiredVersion(r.flag.Version.Golang))
 
 			err = os.WriteFile(p, []byte(c), 0600)
 			if err != nil {
@@ -93,6 +93,7 @@ func (r *runner) run() error {
 
 func (r *runner) data() any {
 	type Data struct {
+		Binary  bool
 		Command string
 		Env     map[string]string
 		Private string
@@ -101,6 +102,7 @@ func (r *runner) data() any {
 	}
 
 	return Data{
+		Binary:  r.flag.Binary,
 		Command: strings.Join(os.Args, " "),
 		Env:     env.Env(),
 		Private: r.flag.Private,

--- a/cmd/create/golang/template.go
+++ b/cmd/create/golang/template.go
@@ -41,6 +41,15 @@ jobs:
           go mod tidy
           git diff --exit-code
 
+      - name: "Build Go Binary"
+        env:
+          CGO_ENABLED: "0"
+{{- range $k, $v := .Env }}
+          {{ $k }}: "{{ $v }}"
+{{- end }}
+        run: |
+          go build .
+
       - name: "Check Go Tests"
 {{- if .Env }}
         env:

--- a/cmd/create/golang/template.go
+++ b/cmd/create/golang/template.go
@@ -15,7 +15,6 @@ jobs:
   go-build:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"
 
@@ -41,7 +40,7 @@ jobs:
           go mod tidy
           git diff --exit-code
 
-      - name: "Build Go Binary"
+      - name: "Run Go Build"
         env:
           CGO_ENABLED: "0"
 {{- range $k, $v := .Env }}

--- a/cmd/create/golang/template.go
+++ b/cmd/create/golang/template.go
@@ -48,7 +48,11 @@ jobs:
           {{ $k }}: "{{ $v }}"
 {{- end }}
         run: |
+{{- if .Binary }}
           go build .
+{{- else }}
+          go build ./...
+{{- end }}
 
       - name: "Check Go Tests"
 {{- if .Env }}

--- a/cmd/create/npm/template.go
+++ b/cmd/create/npm/template.go
@@ -31,7 +31,6 @@ jobs:
 
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"
 

--- a/cmd/create/typescript/template.go
+++ b/cmd/create/typescript/template.go
@@ -15,7 +15,6 @@ jobs:
   typescript:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"
 

--- a/pkg/generator/pbfgo/template.go
+++ b/pkg/generator/pbfgo/template.go
@@ -22,7 +22,6 @@ jobs:
   pbf-go:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"
 

--- a/pkg/generator/pbfgo/testdata/workflow/case-0.golden
+++ b/pkg/generator/pbfgo/testdata/workflow/case-0.golden
@@ -20,7 +20,6 @@ jobs:
   pbf-go:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 

--- a/pkg/generator/pbfgo/testdata/workflow/case-1.golden
+++ b/pkg/generator/pbfgo/testdata/workflow/case-1.golden
@@ -20,7 +20,6 @@ jobs:
   pbf-go:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 

--- a/pkg/generator/pbflint/template.go
+++ b/pkg/generator/pbflint/template.go
@@ -23,7 +23,6 @@ jobs:
   pbf-lint:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"
 

--- a/pkg/generator/pbflint/testdata/workflow/case-0.golden
+++ b/pkg/generator/pbflint/testdata/workflow/case-0.golden
@@ -21,7 +21,6 @@ jobs:
   pbf-lint:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 

--- a/pkg/generator/pbflint/testdata/workflow/case-1.golden
+++ b/pkg/generator/pbflint/testdata/workflow/case-1.golden
@@ -21,7 +21,6 @@ jobs:
   pbf-lint:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 

--- a/pkg/generator/pbfts/template.go
+++ b/pkg/generator/pbfts/template.go
@@ -22,7 +22,6 @@ jobs:
   pbf-ts:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v{{ .Version.Checkout }}"
 

--- a/pkg/generator/pbfts/testdata/workflow/case-0.golden
+++ b/pkg/generator/pbfts/testdata/workflow/case-0.golden
@@ -20,7 +20,6 @@ jobs:
   pbf-ts:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 

--- a/pkg/generator/pbfts/testdata/workflow/case-1.golden
+++ b/pkg/generator/pbfts/testdata/workflow/case-1.golden
@@ -20,7 +20,6 @@ jobs:
   pbf-ts:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 


### PR DESCRIPTION
Some builds in GitHub Actions started to time out during the linting step, which is caused by missing build caches, since we run Go tests with the `-race` flag. Adding the separate and clean `go build .` step before running the tests and before running the linting step creates the effect of warming up the build cache, which can then be reused by the linting step.