### PR TITLE
allow dependabot group for aws sdk in golang

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,20 +10,13 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"
-
   - package-ecosystem: "gomod"
     directory: "/"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"

--- a/cmd/create/dependabot/flag.go
+++ b/cmd/create/dependabot/flag.go
@@ -12,6 +12,7 @@ import (
 
 type flag struct {
 	Branch    string
+	Combine   []string
 	Reviewers []string
 	Version   struct {
 		Golang string
@@ -20,6 +21,7 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Branch, "branch", "b", "main", "Dependabort target branch to merge pull requests into.")
+	cmd.Flags().StringSliceVarP(&f.Combine, "combine", "c", []string{}, "Combine dependency updates of a kind, e.g. gomod:github.com/aws/aws-sdk-go-v2.")
 	cmd.Flags().StringSliceVarP(&f.Reviewers, "reviewers", "r", []string{}, "Reviewers assigned to dependabot PRs, e.g. @xh3b4sd.")
 	cmd.Flags().StringVarP(&f.Version.Golang, "version-golang", "g", version.Golang, "Golang version to use in, e.g. workflow files.")
 }
@@ -35,9 +37,17 @@ func (f *flag) Validate() error {
 		if len(f.Reviewers) == 0 {
 			return tracer.Mask(runtime.InvalidFlagError, tracer.Context{Key: "reason", Value: "-r/--reviewers must not be empty"})
 		}
-		for _, r := range f.Reviewers {
-			if !strings.HasPrefix(r, "@") {
+		for _, x := range f.Reviewers {
+			if !strings.HasPrefix(x, "@") {
 				return tracer.Mask(runtime.InvalidFlagError, tracer.Context{Key: "reason", Value: "-r/--reviewers must start with @"})
+			}
+		}
+	}
+
+	{
+		for _, x := range f.Combine {
+			if !strings.HasPrefix(x, "gomod:") {
+				return tracer.Mask(runtime.InvalidFlagError, tracer.Context{Key: "reason", Value: "-c/--combine must start with gomod:"})
 			}
 		}
 	}

--- a/cmd/create/dependabot/run.go
+++ b/cmd/create/dependabot/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -77,8 +78,13 @@ func (r *run) run(_ *cobra.Command, _ []string) error {
 }
 
 func (r *run) dependabotData() any {
+	type Group struct {
+		Aws bool
+	}
+
 	type Ecosystem struct {
-		Name string
+		Group Group
+		Name  string
 	}
 
 	type Data struct {
@@ -102,6 +108,9 @@ func (r *run) dependabotData() any {
 
 		if file.Exists("go.mod") && file.Exists("go.sum") {
 			ecosystems = append(ecosystems, Ecosystem{
+				Group: Group{
+					Aws: slices.Contains(r.flag.Combine, "gomod:github.com/aws/aws-sdk-go-v2"),
+				},
 				Name: "gomod",
 			})
 		}

--- a/cmd/create/dependabot/template.go
+++ b/cmd/create/dependabot/template.go
@@ -13,11 +13,16 @@ updates:
 {{- range $e := .Ecosystems }}
   - package-ecosystem: "{{ $e.Name }}"
     directory: "/"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"
-{{ end }}`
+{{- if $e.Group.Aws }}
+    groups:
+      aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2"
+          - "github.com/aws/aws-sdk-go-v2/*"
+{{- end }}
+{{- end }}
+`

--- a/pkg/generator/pbfgo/testdata/workflow/case-0.golden
+++ b/pkg/generator/pbfgo/testdata/workflow/case-0.golden
@@ -21,7 +21,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Setup Git Project"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Setup Go Env"
         uses: "actions/setup-go@v5"

--- a/pkg/generator/pbfgo/testdata/workflow/case-1.golden
+++ b/pkg/generator/pbfgo/testdata/workflow/case-1.golden
@@ -21,7 +21,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Setup Git Project"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Setup Go Env"
         uses: "actions/setup-go@v5"

--- a/pkg/generator/pbflint/testdata/workflow/case-0.golden
+++ b/pkg/generator/pbflint/testdata/workflow/case-0.golden
@@ -22,7 +22,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Setup Git Project"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Setup Go Env"
         uses: "actions/setup-go@v5"

--- a/pkg/generator/pbflint/testdata/workflow/case-1.golden
+++ b/pkg/generator/pbflint/testdata/workflow/case-1.golden
@@ -22,7 +22,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Setup Git Project"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Setup Go Env"
         uses: "actions/setup-go@v5"

--- a/pkg/generator/pbfts/testdata/workflow/case-0.golden
+++ b/pkg/generator/pbfts/testdata/workflow/case-0.golden
@@ -21,7 +21,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Setup Git Project"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Setup Typescript Env"
         uses: "actions/setup-node@v4"

--- a/pkg/generator/pbfts/testdata/workflow/case-1.golden
+++ b/pkg/generator/pbfts/testdata/workflow/case-1.golden
@@ -21,7 +21,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Setup Git Project"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Setup Typescript Env"
         uses: "actions/setup-node@v4"

--- a/pkg/version/checkout.go
+++ b/pkg/version/checkout.go
@@ -1,5 +1,5 @@
 package version
 
 const (
-	Checkout = "4"
+	Checkout = "5"
 )


### PR DESCRIPTION
* getting updates every day has been stressful for some projects, here we set the interval for updates to `weekly`
* we stop ignoring patch updates, which should be useful on a weekly schedule to get security related updates in
* we add grouping for certain dependencies, so that we can get a single pull request for libraries that typically create many separate pull requests otherwise
* this also bumps the official checkout action to major version 5